### PR TITLE
#5 `학습컨텐츠 등록` Usecase 구현

### DIFF
--- a/app-core/src/main/kotlin/com/flab/hsw/core/domain/content/Content.kt
+++ b/app-core/src/main/kotlin/com/flab/hsw/core/domain/content/Content.kt
@@ -1,0 +1,20 @@
+package com.flab.hsw.core.domain.content
+
+import com.flab.hsw.core.domain.SoftDeletable
+import com.flab.hsw.core.domain.user.User
+import java.time.Instant
+import java.util.*
+
+interface Content : SoftDeletable {
+    val id: UUID
+    val url: String
+    val description: String
+    val provider: User
+    val registeredAt: Instant
+    val lastUpdateAt: Instant
+
+    companion object {
+        const val LENGTH_DESCRIPTION_MIN = 1
+        const val LENGTH_DESCRIPTION_MAX = 200
+    }
+}

--- a/app-core/src/main/kotlin/com/flab/hsw/core/domain/content/aggregate/ContentModel.kt
+++ b/app-core/src/main/kotlin/com/flab/hsw/core/domain/content/aggregate/ContentModel.kt
@@ -1,0 +1,42 @@
+package com.flab.hsw.core.domain.content.aggregate
+
+import com.flab.hsw.core.domain.content.Content
+import com.flab.hsw.core.domain.user.User
+import java.net.URLDecoder
+import java.time.Instant
+import java.util.*
+
+internal data class ContentModel(
+    override val id: UUID,
+    override val url: String,
+    override val description: String,
+    override val provider: User,
+    override val registeredAt: Instant,
+    override val lastUpdateAt: Instant,
+    override val deleted: Boolean = true
+) : Content {
+    override fun delete(): Content = this.copy(
+        deleted = true,
+        lastUpdateAt = Instant.now()
+    )
+
+    companion object {
+        fun create(
+            url: String,
+            description: String,
+            provider: User
+        ): ContentModel {
+            val now = Instant.now()
+
+            return ContentModel(
+                id = UUID.randomUUID(),
+                url = URLDecoder.decode(url, Charsets.UTF_8),
+                description = description,
+                provider = provider,
+                registeredAt = now,
+                lastUpdateAt = now,
+                deleted = false
+            )
+        }
+    }
+}

--- a/app-core/src/main/kotlin/com/flab/hsw/core/domain/content/repository/ContentRepository.kt
+++ b/app-core/src/main/kotlin/com/flab/hsw/core/domain/content/repository/ContentRepository.kt
@@ -1,0 +1,7 @@
+package com.flab.hsw.core.domain.content.repository
+
+import com.flab.hsw.core.domain.content.Content
+
+interface ContentRepository {
+    fun save(content: Content): Content
+}

--- a/app-core/src/main/kotlin/com/flab/hsw/core/domain/content/usecase/CreateContentUseCase.kt
+++ b/app-core/src/main/kotlin/com/flab/hsw/core/domain/content/usecase/CreateContentUseCase.kt
@@ -1,0 +1,46 @@
+package com.flab.hsw.core.domain.content.usecase
+
+import com.flab.hsw.core.annotation.UseCase
+import com.flab.hsw.core.domain.content.Content
+import com.flab.hsw.core.domain.content.aggregate.ContentModel
+import com.flab.hsw.core.domain.content.repository.ContentRepository
+import com.flab.hsw.core.domain.user.exception.UserByIdNotFoundException
+import com.flab.hsw.core.domain.user.repository.UserRepository
+import java.util.*
+
+interface CreateContentUseCase {
+    fun createContent(providerUserId: UUID, message: CreateContentMessage): Content
+
+    interface CreateContentMessage {
+        val url: String
+        val description: String
+    }
+
+    companion object {
+        fun newInstance(
+            contents: ContentRepository,
+            users: UserRepository
+        ): CreateContentUseCase = CreateContentUseCaseImpl(
+            contents = contents,
+            users = users
+        )
+    }
+}
+
+@UseCase
+internal class CreateContentUseCaseImpl(
+    private val contents: ContentRepository,
+    private val users: UserRepository
+) : CreateContentUseCase {
+    override fun createContent(providerUserId: UUID, message: CreateContentUseCase.CreateContentMessage): Content {
+        val provider = users.findByUuid(providerUserId) ?: throw UserByIdNotFoundException(providerUserId)
+
+        val content = ContentModel.create(
+            url = message.url,
+            description = message.description,
+            provider = provider
+        )
+
+        return contents.save(content)
+    }
+}

--- a/app-core/src/test/kotlin/test/domain/content/ContentTestUtils.kt
+++ b/app-core/src/test/kotlin/test/domain/content/ContentTestUtils.kt
@@ -1,0 +1,29 @@
+package test.domain.content
+
+import com.flab.hsw.core.domain.content.Content
+import com.flab.hsw.core.domain.content.usecase.CreateContentUseCase
+import com.github.javafaker.Faker
+import java.util.*
+
+fun randomCreateContentMessage(
+    url: String = Faker().internet().url(),
+    description: String = Faker(Locale.KOREAN).lorem()
+        .characters(Content.LENGTH_DESCRIPTION_MIN, Content.LENGTH_DESCRIPTION_MAX)
+): CreateContentUseCase.CreateContentMessage {
+    data class FakeCreateContentMessage(
+        override val url: String,
+        override val description: String
+    ) : CreateContentUseCase.CreateContentMessage
+
+    return FakeCreateContentMessage(
+        url = url,
+        description = description
+    )
+}
+
+fun randomUrlIncludingKorean(): String {
+    return Faker().internet().url() +
+            "/" + Faker(Locale.KOREAN).address().city() + "-" + Faker(Locale.KOREAN).lorem().word() +
+            "?name=" + Faker(Locale.KOREAN).name().name() +
+            "&company=" + Faker(Locale.KOREAN).company().name()
+}

--- a/app-core/src/test/kotlin/testcase/small/domain/content/CreateContentUseCaseSpec.kt
+++ b/app-core/src/test/kotlin/testcase/small/domain/content/CreateContentUseCaseSpec.kt
@@ -1,0 +1,73 @@
+package testcase.small.domain.content
+
+import com.flab.hsw.core.domain.content.repository.ContentRepository
+import com.flab.hsw.core.domain.content.usecase.CreateContentUseCase
+import com.flab.hsw.core.domain.user.repository.UserRepository
+import com.flab.hsw.lib.annotation.SmallTest
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import test.domain.content.randomCreateContentMessage
+import test.domain.content.randomUrlIncludingKorean
+import test.domain.user.aggregate.randomUser
+import java.net.URLEncoder
+import java.util.*
+
+@SmallTest
+internal class CreateContentUseCaseSpec {
+    private lateinit var sut: CreateContentUseCase
+    private lateinit var contentRepository: ContentRepository
+    private lateinit var userRepository: UserRepository
+
+    @BeforeEach
+    fun setup() {
+        contentRepository = mock()
+        userRepository = mock()
+        sut = CreateContentUseCase.newInstance(contentRepository, userRepository)
+
+        `when`(contentRepository.save(any())).thenAnswer { return@thenAnswer it.arguments[0] }
+        `when`(userRepository.findByUuid(any())).thenAnswer { return@thenAnswer randomUser(id = it.arguments[0] as UUID) }
+    }
+
+    @DisplayName("An user object that fully represents message, is created")
+    @Test
+    fun contentIsCreated() {
+        // given:
+        val message = randomCreateContentMessage()
+
+        // when:
+        val createdContent = sut.createContent(UUID.randomUUID(), message)
+
+        // then:
+        assertAll(
+            { assertThat(createdContent.url, `is`(message.url)) },
+            { assertThat(createdContent.description, `is`(message.description)) }
+        )
+    }
+
+    @DisplayName("Url including korean must be human readable.")
+    @Test
+    fun urlIsDecoded() {
+        // given:
+        val url = randomUrlIncludingKorean()
+
+        val message = randomCreateContentMessage(
+            url = URLEncoder.encode(url, Charsets.UTF_8)
+        )
+
+        // when:
+        val createdContent = sut.createContent(UUID.randomUUID(), message)
+
+        // then:
+        assertAll(
+            { assertThat(createdContent.url, `is`(url)) },
+            { assertThat(createdContent.description, `is`(message.description)) }
+        )
+    }
+}


### PR DESCRIPTION
기존 구조와 같은 형태로 구현하려고 했습니다.

사용자 시나리오 중 컨텐츠의 길이 등 유효성 검사에 대한 내용은 새로운 이슈로 endpoint 작성 시 Request의 `@Valid` 를 통해 추가할 예정입니다.