### PR TITLE
#19 추천 기능을 위한 엔드포인트를 구현하라

### DIFF
--- a/app-core/src/main/kotlin/com/flab/hsw/core/exception/ErrorCodes.kt
+++ b/app-core/src/main/kotlin/com/flab/hsw/core/exception/ErrorCodes.kt
@@ -25,6 +25,8 @@ enum class ErrorCodes(
     CONTENT_BY_ID_NOT_FOUND(2001,""),
     CONTENT_ONLY_RECOMMENDED_ONCE(2002,""),
 
+    UNAUTHORIZED_STATUS_EXCEPTION(3001,""),
+
     UNHANDLED_EXCEPTION(code = -1, "");
 
     val asMessageKey: String = "ERROR_${this.name}"

--- a/app-core/src/main/kotlin/com/flab/hsw/core/exception/external/UnAuthorizedExecutingException.kt
+++ b/app-core/src/main/kotlin/com/flab/hsw/core/exception/external/UnAuthorizedExecutingException.kt
@@ -5,4 +5,4 @@ import com.flab.hsw.core.exception.ExternalException
 
 class UnAuthorizedExecutingException(
     override val message: String = "컨텐츠 추천은 사용자 인증이 완료된 경우에만 가능합니다.",
-) :ExternalException(ErrorCodes.UNHANDLED_EXCEPTION, message)
+) :ExternalException(ErrorCodes.UNAUTHORIZED_STATUS_EXCEPTION, message)

--- a/app-infrastructure/src/main/kotlin/com/flab/hsw/core/jdbc/content/dao/ContentEntityDao.kt
+++ b/app-infrastructure/src/main/kotlin/com/flab/hsw/core/jdbc/content/dao/ContentEntityDao.kt
@@ -1,0 +1,8 @@
+package com.flab.hsw.core.jdbc.content.dao
+
+import org.springframework.stereotype.Repository
+
+internal interface ContentEntityDao
+
+@Repository
+internal class ContentEntityDaoImpl : ContentEntityDao

--- a/app-infrastructure/src/main/kotlin/com/flab/hsw/core/jdbc/content/dao/ContentRecommendationEntityDao.kt
+++ b/app-infrastructure/src/main/kotlin/com/flab/hsw/core/jdbc/content/dao/ContentRecommendationEntityDao.kt
@@ -1,0 +1,8 @@
+package com.flab.hsw.core.jdbc.content.dao
+
+import org.springframework.stereotype.Repository
+
+internal interface ContentRecommendationEntityDao
+
+@Repository
+internal class ContentRecommendationEntityDaoImpl : ContentRecommendationEntityDao

--- a/app-infrastructure/src/main/kotlin/com/flab/hsw/core/jdbc/content/repository/ContentRecommendationRepositoryImpl.kt
+++ b/app-infrastructure/src/main/kotlin/com/flab/hsw/core/jdbc/content/repository/ContentRecommendationRepositoryImpl.kt
@@ -1,0 +1,24 @@
+package com.flab.hsw.core.jdbc.content.repository
+
+import com.flab.hsw.core.domain.content.Content
+import com.flab.hsw.core.domain.content.ContentRecommendation
+import com.flab.hsw.core.domain.content.repository.ContentRecommendationRepository
+import com.flab.hsw.core.domain.content.repository.ContentRepository
+import com.flab.hsw.core.jdbc.content.dao.ContentEntityDao
+import org.springframework.stereotype.Service
+import java.util.*
+
+@Service
+internal class ContentRecommendationRepositoryImpl(
+    val contentEntityDao: ContentEntityDao
+) : ContentRecommendationRepository {
+    override fun findContentRecommendationByUserIdAndContentId(
+        recommendation: ContentRecommendation
+    ): ContentRecommendation? {
+        TODO("Not yet implemented")
+    }
+
+    override fun saveContentRecommendation(recommendation: ContentRecommendation): ContentRecommendation {
+        TODO("Not yet implemented")
+    }
+}

--- a/app-infrastructure/src/main/kotlin/com/flab/hsw/core/jdbc/content/repository/ContentRepositoryImpl.kt
+++ b/app-infrastructure/src/main/kotlin/com/flab/hsw/core/jdbc/content/repository/ContentRepositoryImpl.kt
@@ -1,0 +1,21 @@
+package com.flab.hsw.core.jdbc.content.repository
+
+import com.flab.hsw.core.domain.content.Content
+import com.flab.hsw.core.domain.content.ContentRecommendation
+import com.flab.hsw.core.domain.content.repository.ContentRepository
+import com.flab.hsw.core.jdbc.content.dao.ContentEntityDao
+import org.springframework.stereotype.Service
+import java.util.*
+
+@Service
+internal class ContentRepositoryImpl(
+    val contentEntityDao: ContentEntityDao
+) : ContentRepository {
+    override fun save(content: Content): Content {
+        TODO("Not yet implemented")
+    }
+
+    override fun findByUuid(uuid: UUID): Content? {
+        TODO("Not yet implemented")
+    }
+}

--- a/app-main/src/main/kotlin/com/flab/hsw/advice/errorhandler/ErrorCodesToHttpStatusMixin.kt
+++ b/app-main/src/main/kotlin/com/flab/hsw/advice/errorhandler/ErrorCodesToHttpStatusMixin.kt
@@ -34,6 +34,8 @@ interface ErrorCodesToHttpStatusMixin {
         CONTENT_BY_ID_NOT_FOUND -> HttpStatus.NOT_FOUND
         CONTENT_ONLY_RECOMMENDED_ONCE -> HttpStatus.CONFLICT
 
+        UNAUTHORIZED_STATUS_EXCEPTION -> HttpStatus.UNAUTHORIZED
+
         UNHANDLED_EXCEPTION -> HttpStatus.INTERNAL_SERVER_ERROR
     }
 }

--- a/app-main/src/main/kotlin/com/flab/hsw/appconfig/bean/ContentRecommendationBeans.kt
+++ b/app-main/src/main/kotlin/com/flab/hsw/appconfig/bean/ContentRecommendationBeans.kt
@@ -1,0 +1,23 @@
+package com.flab.hsw.appconfig.bean
+
+import com.flab.hsw.core.domain.content.repository.ContentRecommendationRepository
+import com.flab.hsw.core.domain.content.repository.ContentRepository
+import com.flab.hsw.core.domain.content.usecase.CreateContentRecommendationUseCase
+import com.flab.hsw.core.domain.user.repository.UserRepository
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class ContentRecommendationBeans {
+
+    @Bean
+    fun createRecommendUseCase(
+        contentRepository: ContentRepository,
+        contentRecommendationRepository: ContentRecommendationRepository,
+        userRepository: UserRepository
+    ) = CreateContentRecommendationUseCase.newInstance(
+        contentRepository = contentRepository,
+        contentRecommendationRepository = contentRecommendationRepository,
+        userRepository = userRepository
+    )
+}

--- a/app-main/src/main/kotlin/com/flab/hsw/endpoint/v1/ApiPathsV1.kt
+++ b/app-main/src/main/kotlin/com/flab/hsw/endpoint/v1/ApiPathsV1.kt
@@ -12,4 +12,10 @@ object ApiPathsV1 {
 
     const val USERS = "$V1/users"
     const val USERS_ID = "$USERS/${ApiVariableV1.PATH_ID}"
+
+    const val CONTENT = "$V1/content"
+
+    const val RECOMMEND = "recommend"
+    const val CONTENT_RECOMMENDATION = "${CONTENT}/${RECOMMEND}"
+
 }

--- a/app-main/src/main/kotlin/com/flab/hsw/endpoint/v1/content/CreateContentRecommendationController.kt
+++ b/app-main/src/main/kotlin/com/flab/hsw/endpoint/v1/content/CreateContentRecommendationController.kt
@@ -1,0 +1,36 @@
+package com.flab.hsw.endpoint.v1.content
+
+import com.flab.hsw.core.domain.content.usecase.CreateContentRecommendationUseCase
+import com.flab.hsw.endpoint.v1.ApiPathsV1
+import com.flab.hsw.endpoint.v1.content.common.ContentRecommendationResponse
+import com.flab.hsw.endpoint.v1.content.recommend.CreateContentRecommendationRequest
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import javax.servlet.http.HttpSession
+
+/**
+ * ```
+ * POST /v1/contents/recommend
+ * Content-Type: application/json
+ * body: {
+ *      "contentId" : "id Value"
+ * }
+ * ```
+ */
+@RequestMapping(
+    produces = [MediaType.APPLICATION_JSON_VALUE],
+)
+interface CreateContentRecommendationController {
+    val useCase: CreateContentRecommendationUseCase
+
+    @RequestMapping(
+        path = [ApiPathsV1.CONTENT_RECOMMENDATION],
+        method = [RequestMethod.POST]
+    )
+    fun createContentRecommendation(
+        session: HttpSession,
+        @RequestBody request: CreateContentRecommendationRequest
+    ): ContentRecommendationResponse
+}

--- a/app-main/src/main/kotlin/com/flab/hsw/endpoint/v1/content/common/ContentRecommendationResponse.kt
+++ b/app-main/src/main/kotlin/com/flab/hsw/endpoint/v1/content/common/ContentRecommendationResponse.kt
@@ -1,0 +1,29 @@
+package com.flab.hsw.endpoint.v1.content.common
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.flab.hsw.core.domain.content.ContentRecommendation
+import java.time.Instant
+import java.util.*
+
+@JsonSerialize
+data class ContentRecommendationResponse(
+    @JsonProperty
+    val userId: UUID,
+
+    @JsonProperty
+    val contentId: UUID,
+
+    @JsonProperty
+    val registeredAt: Instant
+) {
+    companion object {
+        fun from(contentRecommendation: ContentRecommendation) : ContentRecommendationResponse {
+            return ContentRecommendationResponse(
+                contentId = contentRecommendation.contentId,
+                userId = contentRecommendation.recommenderUserId,
+                registeredAt = contentRecommendation.registeredAt
+            )
+        }
+    }
+}

--- a/app-main/src/main/kotlin/com/flab/hsw/endpoint/v1/content/recommend/CreateContentRecommendationControllerImpl.kt
+++ b/app-main/src/main/kotlin/com/flab/hsw/endpoint/v1/content/recommend/CreateContentRecommendationControllerImpl.kt
@@ -1,0 +1,30 @@
+package com.flab.hsw.endpoint.v1.content.recommend
+
+import com.flab.hsw.core.exception.external.UnAuthorizedExecutingException
+import com.flab.hsw.core.domain.content.usecase.CreateContentRecommendationUseCase
+import com.flab.hsw.core.domain.content.usecase.CreateContentRecommendationUseCase.CreateContentRecommendationMessage
+import com.flab.hsw.core.domain.user.User
+import com.flab.hsw.endpoint.v1.content.CreateContentRecommendationController
+import com.flab.hsw.endpoint.v1.content.common.ContentRecommendationResponse
+import org.springframework.web.bind.annotation.RestController
+import javax.servlet.http.HttpSession
+
+@RestController
+internal class CreateContentRecommendationControllerImpl(
+    override val useCase: CreateContentRecommendationUseCase
+) : CreateContentRecommendationController {
+    override fun createContentRecommendation(
+        session: HttpSession,
+        request: CreateContentRecommendationRequest
+    ): ContentRecommendationResponse = ContentRecommendationResponse.from(
+        useCase.createContentRecommendation(
+            CreateContentRecommendationMessage(
+                recommendedContentId = request.contentId,
+                recommenderId = findAuthorizedUserIn(session)?.id ?: throw UnAuthorizedExecutingException()
+            )
+        )
+    )
+}
+
+private fun findAuthorizedUserIn(session: HttpSession): User? =
+    session.getAttribute(User.AUTHORIZED_USER_ALIAS) as User?

--- a/app-main/src/main/kotlin/com/flab/hsw/endpoint/v1/content/recommend/CreateContentRecommendationRequest.kt
+++ b/app-main/src/main/kotlin/com/flab/hsw/endpoint/v1/content/recommend/CreateContentRecommendationRequest.kt
@@ -1,0 +1,14 @@
+package com.flab.hsw.endpoint.v1.content.recommend
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import java.util.*
+import javax.validation.constraints.NotEmpty
+
+@JsonDeserialize
+data class CreateContentRecommendationRequest(
+
+    @field:NotEmpty
+    @JsonProperty
+    val contentId: UUID
+)

--- a/app-main/src/test/kotlin/test/endpoint/v1/content/ContentRecommendationApiDtoTestSupport.kt
+++ b/app-main/src/test/kotlin/test/endpoint/v1/content/ContentRecommendationApiDtoTestSupport.kt
@@ -1,0 +1,20 @@
+/*
+ * kopringboot-multimodule-template
+ * Distributed under MIT licence
+ */
+package test.endpoint.v1.content
+
+import com.flab.hsw.core.domain.user.User
+import com.flab.hsw.endpoint.v1.content.recommend.CreateContentRecommendationRequest
+import com.github.javafaker.Faker
+import org.springframework.mock.web.MockHttpSession
+import test.domain.user.aggregate.randomUser
+import java.util.*
+
+fun randomCreateContentRecommendationRequest(
+    contentId: UUID = UUID.fromString(Faker().internet().uuid())
+) : CreateContentRecommendationRequest = CreateContentRecommendationRequest(contentId)
+
+fun createMockSessionThatContainAuthorizedUser(): MockHttpSession = MockHttpSession().apply {
+    this.setAttribute(User.AUTHORIZED_USER_ALIAS, randomUser())
+}

--- a/app-main/src/test/kotlin/testcase/medium/CreateContentRecommendationControllerMediumTestBase.kt
+++ b/app-main/src/test/kotlin/testcase/medium/CreateContentRecommendationControllerMediumTestBase.kt
@@ -1,0 +1,26 @@
+/*
+ * kopringboot-multimodule-template
+ * Distributed under MIT licence
+ */
+package testcase.medium
+
+import com.flab.hsw.core.domain.content.usecase.CreateContentRecommendationUseCase
+import com.flab.hsw.core.domain.user.User
+import com.flab.hsw.endpoint.health.HealthControllerImpl
+import com.flab.hsw.endpoint.v1.content.recommend.CreateContentRecommendationControllerImpl
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.mock.web.MockHttpSession
+import org.springframework.test.context.ContextConfiguration
+import test.domain.user.aggregate.randomUser
+
+@ContextConfiguration(
+    classes = [
+        HealthControllerImpl::class,
+        CreateContentRecommendationControllerImpl::class
+    ]
+)
+class CreateContentRecommendationControllerMediumTestBase : MockMvcMediumTestBase() {
+
+    @MockBean
+    protected lateinit var createContentRecommendationUseCase: CreateContentRecommendationUseCase
+}

--- a/app-main/src/test/kotlin/testcase/medium/MockMvcMediumTestBase.kt
+++ b/app-main/src/test/kotlin/testcase/medium/MockMvcMediumTestBase.kt
@@ -22,6 +22,7 @@ import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.mock.web.MockHttpSession
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.web.WebAppConfiguration
@@ -107,7 +108,8 @@ class MockMvcMediumTestBase : JsonRequestAssertionsMixin {
         method: HttpMethod,
         endpoint: String,
         payload: Any? = null,
-        vararg queryParams: Pair<String, String?>
+        vararg queryParams: Pair<String, String?>,
+        session: MockHttpSession = MockHttpSession()
     ): MockHttpServletRequestBuilder {
         fun String.urlEncode() = URLEncoder.encode(this, StandardCharsets.UTF_8.toString())
         val requestEndpoint = if (queryParams.isEmpty()) {
@@ -142,6 +144,7 @@ class MockMvcMediumTestBase : JsonRequestAssertionsMixin {
                 .accept(MediaType.APPLICATION_JSON)
                 .characterEncoding(Charsets.UTF_8)
                 .content(jsonPayload)
+                .session(session)
         }
     }
 

--- a/app-main/src/test/kotlin/testcase/medium/UserControllerMediumTestBase.kt
+++ b/app-main/src/test/kotlin/testcase/medium/UserControllerMediumTestBase.kt
@@ -34,7 +34,7 @@ import org.springframework.web.bind.annotation.RestController
         DeleteUserControllerImpl::class,
     ],
 )
-class ControllerMediumTestBase : MockMvcMediumTestBase() {
+class UserControllerMediumTestBase : MockMvcMediumTestBase() {
     @MockBean
     protected lateinit var createUserUseCase: CreateUserUseCase
 

--- a/app-main/src/test/kotlin/testcase/medium/endpoint/v1/content/CreateCreateContentRecommendationRequestSpecRecommendation.kt
+++ b/app-main/src/test/kotlin/testcase/medium/endpoint/v1/content/CreateCreateContentRecommendationRequestSpecRecommendation.kt
@@ -1,0 +1,102 @@
+package testcase.medium.endpoint.v1.content
+
+import com.flab.hsw.core.domain.content.exception.ContentByIdNotFoundException
+import com.flab.hsw.core.domain.content.exception.ContentRecommendationIsAlreadyExistException
+import com.flab.hsw.core.exception.ErrorCodes
+import com.flab.hsw.endpoint.v1.ApiPathsV1
+import org.hamcrest.MatcherAssert.*
+import org.hamcrest.Matchers
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.test.web.servlet.MockMvc
+import test.endpoint.v1.content.randomCreateContentRecommendationRequest
+import test.endpoint.v1.content.createMockSessionThatContainAuthorizedUser
+import testcase.medium.CreateContentRecommendationControllerMediumTestBase
+import java.util.*
+
+class CreateCreateContentRecommendationRequestSpecRecommendation :
+    CreateContentRecommendationControllerMediumTestBase() {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @DisplayName("인증되지 않은 사용자가 컨텐츠 추천 기능을 호출하는 경우, 401 Unauthorized 를 반환합니다.")
+    @Test
+    fun return401UnauthorizedWhenUserIsUnauthorized() {
+        // when:
+        val request = post(
+            endpoint = ApiPathsV1.CONTENT_RECOMMENDATION,
+            payload = randomCreateContentRecommendationRequest()
+        )
+
+        // then:
+        val errorResponse = request.send().expect4xx(HttpStatus.UNAUTHORIZED)
+
+        // expect:
+        assertThat(
+            ErrorCodes.from(errorResponse.code),
+            Matchers.`is`(ErrorCodes.UNAUTHORIZED_STATUS_EXCEPTION)
+        )
+    }
+
+    @DisplayName("사용자가 입력한 컨텐츠 ID가 존재하지 않는 경우, 404 Not Found 를 반환합니다.")
+    @Test
+    fun return400BadRequestWhenMalformedInputV2() {
+        // given:
+        val requestPayload = randomCreateContentRecommendationRequest()
+
+        // and:
+        `when`(createContentRecommendationUseCase.createContentRecommendation(any()))
+            .thenThrow(ContentByIdNotFoundException(requestPayload.contentId))
+
+        // when:
+        val request = request(
+            method = HttpMethod.POST,
+            endpoint = ApiPathsV1.CONTENT_RECOMMENDATION,
+            payload = requestPayload,
+            session = createMockSessionThatContainAuthorizedUser()
+        )
+
+        // then:
+        val errorResponse = request.send().expect4xx(HttpStatus.NOT_FOUND)
+
+        // expert:
+        assertThat(
+            ErrorCodes.from(errorResponse.code),
+            Matchers.`is`(ErrorCodes.CONTENT_BY_ID_NOT_FOUND)
+        )
+    }
+
+    @DisplayName("사용자가 추천한 컨텐츠가 이미 추천된 경우, 409 Conflict 를 반환합니다.")
+    @Test
+    fun return409ConflictWhenContentIsAlreadyRecommended() {
+        // given:
+        val requestPayload = randomCreateContentRecommendationRequest()
+
+        // and:
+        `when`(createContentRecommendationUseCase.createContentRecommendation(any()))
+            .thenThrow(ContentRecommendationIsAlreadyExistException())
+
+        // when:
+        val request = request(
+            method = HttpMethod.POST,
+            endpoint = ApiPathsV1.CONTENT_RECOMMENDATION,
+            payload = requestPayload,
+            session = createMockSessionThatContainAuthorizedUser()
+        )
+
+        // then:
+        val errorResponse = request.send().expect4xx(HttpStatus.CONFLICT)
+
+        // expert:
+        assertThat(
+            ErrorCodes.from(errorResponse.code),
+            Matchers.`is`(ErrorCodes.CONTENT_ONLY_RECOMMENDED_ONCE)
+        )
+    }
+}

--- a/app-main/src/test/kotlin/testcase/medium/endpoint/v1/user/CreateUserRequestSpec.kt
+++ b/app-main/src/test/kotlin/testcase/medium/endpoint/v1/user/CreateUserRequestSpec.kt
@@ -16,14 +16,14 @@ import org.hamcrest.Matchers.`is`
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
-import testcase.medium.ControllerMediumTestBase
+import testcase.medium.UserControllerMediumTestBase
 import java.util.*
 import java.util.stream.Stream
 
 /**
  * @since 2021-08-10
  */
-class CreateUserRequestSpec : ControllerMediumTestBase() {
+class CreateUserRequestSpec : UserControllerMediumTestBase() {
     @ParameterizedTest(name = "Fails if it is {0} characters")
     @MethodSource("badNicknames")
     fun failIfNicknamesAreBad(

--- a/app-main/src/test/kotlin/testcase/medium/endpoint/v1/user/EditUserRequestSpec.kt
+++ b/app-main/src/test/kotlin/testcase/medium/endpoint/v1/user/EditUserRequestSpec.kt
@@ -15,14 +15,14 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import test.endpoint.v1.usersId
-import testcase.medium.ControllerMediumTestBase
+import testcase.medium.UserControllerMediumTestBase
 import java.util.*
 import java.util.stream.Stream
 
 /**
  * @since 2021-08-10
  */
-class EditUserRequestSpec : ControllerMediumTestBase() {
+class EditUserRequestSpec : UserControllerMediumTestBase() {
     @ParameterizedTest(name = "Fails if it is {0} characters")
     @MethodSource("badNicknames")
     fun failIfNicknamesAreBad(


### PR DESCRIPTION
### Context and motivation
- #12 , 이후 `추천 기능`의 엔드포인트를 구현합니다.
- `Content` 객체 생성이 필요한 Large Test는 #14 Merge 이후 추가할 예정입니다.
---

### Key implements

- `인증된 사용자`를 가져오는 로직은 `HttpSession`에 저장해둔 `User` 객체를 사용하도록 구현했습니다.

---

### Notes
❌ 