### PR TITLE
#24 CreateUserRequestSpec.failIfPasswordsAreBad() 에서 발생하는 테스트 실패 문제를 수정하라

### DIFF
--- a/app-main/src/test/kotlin/testcase/medium/endpoint/v1/user/CreateUserRequestSpec.kt
+++ b/app-main/src/test/kotlin/testcase/medium/endpoint/v1/user/CreateUserRequestSpec.kt
@@ -162,8 +162,10 @@ class CreateUserRequestSpec : UserControllerMediumTestBase() {
             Arguments.of("emptyValue", ""),
             Arguments.of(
                 "Do not matched in given expression",
-                FakeValuesService(Locale.ENGLISH, RandomService()).regexify("[a-z0-9]{${User.LENGTH_NICKNAME_MAX+1},}"),
-                FakeValuesService(Locale.ENGLISH, RandomService()).regexify("[a-z0-9]{1,${User.LENGTH_LOGIN_ID_MIN}}")
+                FakeValuesService(Locale.ENGLISH,
+                    RandomService()).regexify("[a-z0-9]{${User.LENGTH_LOGIN_ID_MAX + 1},}"),
+                FakeValuesService(Locale.ENGLISH,
+                    RandomService()).regexify("[a-z0-9]{1,${User.LENGTH_LOGIN_ID_MIN - 1}}")
             )
         )
 
@@ -172,8 +174,10 @@ class CreateUserRequestSpec : UserControllerMediumTestBase() {
             Arguments.of("emptyValue", ""),
             Arguments.of(
                 "Do not matched in given expression",
-                FakeValuesService(Locale.ENGLISH, RandomService()).regexify("[a-z0-9]{1,${User.LENGTH_PASSWORD_MIN}}"),
-                FakeValuesService(Locale.ENGLISH, RandomService()).regexify("[a-z0-9]{${User.LENGTH_PASSWORD_MAX+1}}")
+                FakeValuesService(Locale.ENGLISH,
+                    RandomService()).regexify("[a-z0-9]{1,${User.LENGTH_PASSWORD_MIN - 1}}"),
+                FakeValuesService(Locale.ENGLISH,
+                    RandomService()).regexify("[a-z0-9]{${User.LENGTH_PASSWORD_MAX + 1}}")
             )
         )
     }


### PR DESCRIPTION
### Context and motivation
- #24 수정 사항입니다.

---

### Key implements

- 테스트 데이터를 생성 시 필요한 정규식(`[a-z0-9]{1,${User.LENGTH_PASSWORD_MIN - 1}}`)을 수정했습니다. 
---

### Notes
❌ 