### PR TITLE
Access Token 사용 시 발생하는 요청 시 비효율을 보완하는 새로운 토큰을 추가하라

### DIFF
--- a/app-main/src/main/kotlin/com/flab/hsw/appconfig/bean/AuthenticationBeans.kt
+++ b/app-main/src/main/kotlin/com/flab/hsw/appconfig/bean/AuthenticationBeans.kt
@@ -21,6 +21,9 @@ class AuthenticationBeans {
     @Value("\${jwt.token.expiredPeriod.access}")
     private lateinit var accessTokenExpiredTime: String
 
+    @Value("\${jwt.token.expiredPeriod.refresh}")
+    private lateinit var refreshTokenExpiredTime: String
+
     @Bean
     fun jwtTokenManager(): JwtTokenManager {
         val keyFactory = KeyFactory.getInstance("RSA")
@@ -28,6 +31,7 @@ class AuthenticationBeans {
             publicKey = keyFactory.generatePublic(X509EncodedKeySpec(Base64.getDecoder().decode(publicKey))),
             privateKey = keyFactory.generatePrivate(PKCS8EncodedKeySpec(Base64.getDecoder().decode(privateKey))),
             accessTokenExpirePeriod = accessTokenExpiredTime.toLong(),
+            refreshTokenExpirePeriod = refreshTokenExpiredTime.toLong()
         )
     }
 }

--- a/app-main/src/main/kotlin/com/flab/hsw/appconfig/bean/AuthenticationBeans.kt
+++ b/app-main/src/main/kotlin/com/flab/hsw/appconfig/bean/AuthenticationBeans.kt
@@ -18,8 +18,8 @@ class AuthenticationBeans {
     @Value("\${auth.rsa.private}")
     private lateinit var privateKey: String
 
-    @Value("\${jwt.token.expiredPeriod}")
-    private lateinit var expiredPeriod: String
+    @Value("\${jwt.token.expiredPeriod.access}")
+    private lateinit var accessTokenExpiredTime: String
 
     @Bean
     fun jwtTokenManager(): JwtTokenManager {
@@ -27,7 +27,7 @@ class AuthenticationBeans {
         return JwtTokenManager(
             publicKey = keyFactory.generatePublic(X509EncodedKeySpec(Base64.getDecoder().decode(publicKey))),
             privateKey = keyFactory.generatePrivate(PKCS8EncodedKeySpec(Base64.getDecoder().decode(privateKey))),
-            expirePeriod = expiredPeriod.toLong()
+            accessTokenExpirePeriod = accessTokenExpiredTime.toLong(),
         )
     }
 }

--- a/app-main/src/main/kotlin/com/flab/hsw/endpoint/ApiPaths.kt
+++ b/app-main/src/main/kotlin/com/flab/hsw/endpoint/ApiPaths.kt
@@ -15,7 +15,6 @@ object ApiPaths {
 
     /** Replace this to spring-actuator if needed */
     const val HEALTH = "/health"
-    const val PUBLIC_KEY = "/auth/key"
 
     const val LATEST_VERSION = ApiPathsV1.V1
 }

--- a/app-main/src/main/kotlin/com/flab/hsw/endpoint/ApiPaths.kt
+++ b/app-main/src/main/kotlin/com/flab/hsw/endpoint/ApiPaths.kt
@@ -16,5 +16,7 @@ object ApiPaths {
     /** Replace this to spring-actuator if needed */
     const val HEALTH = "/health"
 
+    const val REFRESH_TOKEN = "/auth/refresh"
+
     const val LATEST_VERSION = ApiPathsV1.V1
 }

--- a/app-main/src/main/kotlin/com/flab/hsw/endpoint/auth/AuthenticationController.kt
+++ b/app-main/src/main/kotlin/com/flab/hsw/endpoint/auth/AuthenticationController.kt
@@ -1,0 +1,47 @@
+package com.flab.hsw.endpoint.auth
+
+import com.flab.hsw.endpoint.ApiPaths
+import com.flab.hsw.endpoint.v1.user.login.UserLoginResponse
+import com.flab.hsw.util.JwtTokenManager
+import com.flab.hsw.util.JwtTokenManager.Companion.AUTHORIZATION_HEADER
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.RestController
+import javax.security.auth.login.CredentialNotFoundException
+import javax.servlet.http.HttpServletRequest
+
+/**
+ * ```
+ * POST /auth/refresh
+ *
+ * Content-Type: application/json
+ * ```
+ */
+@RequestMapping(
+    produces = [MediaType.APPLICATION_JSON_VALUE],
+)
+interface AuthenticationController {
+    val jwtTokenManager: JwtTokenManager
+
+    @RequestMapping(
+        path = [ApiPaths.REFRESH_TOKEN], method = [RequestMethod.POST]
+    )
+    fun recreateAccessToken(request: HttpServletRequest): UserLoginResponse
+}
+
+@RestController
+internal class AuthenticationControllerImpl(
+    override val jwtTokenManager: JwtTokenManager
+) : AuthenticationController {
+    override fun recreateAccessToken(request: HttpServletRequest): UserLoginResponse {
+        val claimsFromRefreshToken = jwtTokenManager.validAndReturnClaims(
+            request.getHeader(AUTHORIZATION_HEADER) ?: throw CredentialNotFoundException()
+        )
+
+        return UserLoginResponse(
+            authorizedToken = jwtTokenManager.createAccessTokenBy(claimsFromRefreshToken.body.subject),
+            expiredIn = jwtTokenManager.returnAccessTokenExpiredIn()
+        )
+    }
+}

--- a/app-main/src/main/kotlin/com/flab/hsw/endpoint/v1/user/UserLoginController.kt
+++ b/app-main/src/main/kotlin/com/flab/hsw/endpoint/v1/user/UserLoginController.kt
@@ -7,6 +7,7 @@ import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
+import javax.servlet.http.HttpServletResponse
 import javax.validation.Valid
 
 @RequestMapping(
@@ -18,5 +19,5 @@ interface UserLoginController {
         path = [ApiPathsV1.USER_LOGIN],
         method = [RequestMethod.POST]
     )
-    fun login(@Valid @RequestBody request: UserLoginRequest): UserLoginResponse
+    fun login(@Valid @RequestBody request: UserLoginRequest, response : HttpServletResponse): UserLoginResponse
 }

--- a/app-main/src/main/kotlin/com/flab/hsw/endpoint/v1/user/login/UserLoginControllerImpl.kt
+++ b/app-main/src/main/kotlin/com/flab/hsw/endpoint/v1/user/login/UserLoginControllerImpl.kt
@@ -21,7 +21,7 @@ internal class UserLoginControllerImpl(
             jwtTokenManager.createRefreshToken(loginSuccessUser.loginId)))
 
         return UserLoginResponse(
-            authorizedToken = jwtTokenManager.createBy(userLoginUseCase.loginProcess(request)),
+            authorizedToken = jwtTokenManager.createAccessTokenBy(loginSuccessUser.loginId),
             expiredIn = jwtTokenManager.returnAccessTokenExpiredIn()
         )
     }

--- a/app-main/src/main/kotlin/com/flab/hsw/endpoint/v1/user/login/UserLoginControllerImpl.kt
+++ b/app-main/src/main/kotlin/com/flab/hsw/endpoint/v1/user/login/UserLoginControllerImpl.kt
@@ -1,16 +1,25 @@
 package com.flab.hsw.endpoint.v1.user.login
 
-import com.flab.hsw.util.JwtTokenManager
 import com.flab.hsw.core.domain.user.usecase.UserLoginUseCase
 import com.flab.hsw.endpoint.v1.user.UserLoginController
+import com.flab.hsw.util.JwtTokenManager
+import com.flab.hsw.util.JwtTokenManager.Companion.REFRESH_TOKEN_COOKIE_KEY
+import com.flab.hsw.util.addCookieWithHttpOnly
 import org.springframework.web.bind.annotation.RestController
+import javax.servlet.http.HttpServletResponse
 
 @RestController
 internal class UserLoginControllerImpl(
     private val userLoginUseCase: UserLoginUseCase,
     private val jwtTokenManager: JwtTokenManager
 ) : UserLoginController {
-    override fun login(request: UserLoginRequest): UserLoginResponse {
+    override fun login(request: UserLoginRequest, response: HttpServletResponse): UserLoginResponse {
+        val loginSuccessUser = userLoginUseCase.loginProcess(request)
+
+        response.addCookieWithHttpOnly(Pair(
+            REFRESH_TOKEN_COOKIE_KEY,
+            jwtTokenManager.createRefreshToken(loginSuccessUser.loginId)))
+
         return UserLoginResponse(
             authorizedToken = jwtTokenManager.createBy(userLoginUseCase.loginProcess(request)),
             expiredIn = jwtTokenManager.returnAccessTokenExpiredIn()

--- a/app-main/src/main/kotlin/com/flab/hsw/endpoint/v1/user/login/UserLoginControllerImpl.kt
+++ b/app-main/src/main/kotlin/com/flab/hsw/endpoint/v1/user/login/UserLoginControllerImpl.kt
@@ -13,7 +13,7 @@ internal class UserLoginControllerImpl(
     override fun login(request: UserLoginRequest): UserLoginResponse {
         return UserLoginResponse(
             authorizedToken = jwtTokenManager.createBy(userLoginUseCase.loginProcess(request)),
-            expiredIn = jwtTokenManager.returnExpiredIn()
+            expiredIn = jwtTokenManager.returnAccessTokenExpiredIn()
         )
     }
 }

--- a/app-main/src/main/kotlin/com/flab/hsw/interceptor/AuthenticationInterceptor.kt
+++ b/app-main/src/main/kotlin/com/flab/hsw/interceptor/AuthenticationInterceptor.kt
@@ -21,7 +21,7 @@ class AuthenticationInterceptor(
             val claims = jwtTokenManager.validAndReturnClaims(
                 request.getHeader(AUTHORIZATION_HEADER) ?: throw CredentialNotFoundException()
             )
-            request.setAttribute(AUTHORIZED_USER_ID_ALIAS, claims?.body?.subject)
+            request.setAttribute(AUTHORIZED_USER_ID_ALIAS, claims.body.subject)
         }
         return true
     }

--- a/app-main/src/main/kotlin/com/flab/hsw/util/JwtTokenManager.kt
+++ b/app-main/src/main/kotlin/com/flab/hsw/util/JwtTokenManager.kt
@@ -22,9 +22,9 @@ class JwtTokenManager(
     private val refreshTokenExpirePeriod: Long
 ) {
 
-    fun createBy(loginSuccessUser: User): String {
+    fun createAccessTokenBy(userLoginId: String): String {
         return Jwts.builder()
-            .setSubject(loginSuccessUser.loginId)
+            .setSubject(userLoginId)
             .setIssuedAt(Date.from(Instant.now()))
             .setExpiration(Date.from(returnAccessTokenExpiredIn()))
             .signWith(privateKey)

--- a/app-main/src/main/kotlin/com/flab/hsw/util/JwtTokenManager.kt
+++ b/app-main/src/main/kotlin/com/flab/hsw/util/JwtTokenManager.kt
@@ -1,7 +1,8 @@
 package com.flab.hsw.util
 
-import com.flab.hsw.core.domain.user.User
-import io.jsonwebtoken.*
+import io.jsonwebtoken.Claims
+import io.jsonwebtoken.Jws
+import io.jsonwebtoken.Jwts
 import java.security.PrivateKey
 import java.security.PublicKey
 import java.time.Instant
@@ -18,6 +19,7 @@ class JwtTokenManager(
     private val publicKey: PublicKey,
     private val privateKey: PrivateKey,
     private val accessTokenExpirePeriod: Long,
+    private val refreshTokenExpirePeriod: Long
 ) {
 
     fun createBy(loginSuccessUser: User): String {
@@ -25,6 +27,15 @@ class JwtTokenManager(
             .setSubject(loginSuccessUser.loginId)
             .setIssuedAt(Date.from(Instant.now()))
             .setExpiration(Date.from(returnAccessTokenExpiredIn()))
+            .signWith(privateKey)
+            .compact()
+    }
+
+    fun createRefreshToken(userLoginId: String): String {
+        return Jwts.builder()
+            .setIssuedAt(Date.from(Instant.now()))
+            .setSubject(userLoginId)
+            .setExpiration(Date.from(returnRefreshTokenExpiredIn()))
             .signWith(privateKey)
             .compact()
     }
@@ -37,10 +48,12 @@ class JwtTokenManager(
     }
     fun returnAccessTokenExpiredIn(): Instant = Instant.now().plusSeconds(accessTokenExpirePeriod)
 
+    private fun returnRefreshTokenExpiredIn(): Instant = Instant.now().plusSeconds(refreshTokenExpirePeriod)
 
     companion object {
 
         const val AUTHORIZATION_HEADER = "Authorization"
         const val BEARER_PREFIX = "Bearer "
+        const val REFRESH_TOKEN_COOKIE_KEY = "refreshToken"
     }
 }

--- a/app-main/src/main/kotlin/com/flab/hsw/util/JwtTokenManager.kt
+++ b/app-main/src/main/kotlin/com/flab/hsw/util/JwtTokenManager.kt
@@ -40,7 +40,7 @@ class JwtTokenManager(
             .compact()
     }
 
-    fun validAndReturnClaims(token: String): Jws<Claims>? {
+    fun validAndReturnClaims(token: String): Jws<Claims> {
         return Jwts.parserBuilder()
             .setSigningKey(publicKey)
             .build()

--- a/app-main/src/main/kotlin/com/flab/hsw/util/JwtTokenManager.kt
+++ b/app-main/src/main/kotlin/com/flab/hsw/util/JwtTokenManager.kt
@@ -17,14 +17,14 @@ import java.util.*
 class JwtTokenManager(
     private val publicKey: PublicKey,
     private val privateKey: PrivateKey,
-    private val expirePeriod: Long
+    private val accessTokenExpirePeriod: Long,
 ) {
 
     fun createBy(loginSuccessUser: User): String {
         return Jwts.builder()
             .setSubject(loginSuccessUser.loginId)
             .setIssuedAt(Date.from(Instant.now()))
-            .setExpiration(Date.from(returnExpiredIn()))
+            .setExpiration(Date.from(returnAccessTokenExpiredIn()))
             .signWith(privateKey)
             .compact()
     }
@@ -35,8 +35,8 @@ class JwtTokenManager(
             .build()
             .parseClaimsJws(token.removePrefix(BEARER_PREFIX))
     }
+    fun returnAccessTokenExpiredIn(): Instant = Instant.now().plusSeconds(accessTokenExpirePeriod)
 
-    fun returnExpiredIn(): Instant = Instant.now().plusSeconds(expirePeriod)
 
     companion object {
 

--- a/app-main/src/main/kotlin/com/flab/hsw/util/ServletResponseUtils.kt
+++ b/app-main/src/main/kotlin/com/flab/hsw/util/ServletResponseUtils.kt
@@ -1,0 +1,14 @@
+/*
+ * kopringboot-multimodule-template
+ * Distributed under MIT licence
+ */
+package com.flab.hsw.util
+
+import javax.servlet.http.Cookie
+import javax.servlet.http.HttpServletResponse
+
+fun HttpServletResponse.addCookieWithHttpOnly(keyValue: Pair<String, String>) {
+    val cookie = Cookie(keyValue.first, keyValue.second)
+    cookie.isHttpOnly = true
+    addCookie(cookie)
+}

--- a/app-main/src/main/resources/application.yml
+++ b/app-main/src/main/resources/application.yml
@@ -44,4 +44,5 @@ auth:
 
 jwt:
   token:
-    expiredPeriod: 7200
+    expiredPeriod:
+      access: 7200

--- a/app-main/src/main/resources/application.yml
+++ b/app-main/src/main/resources/application.yml
@@ -46,3 +46,4 @@ jwt:
   token:
     expiredPeriod:
       access: 7200
+      refresh: 1209600

--- a/app-main/src/test/kotlin/test/endpoint/v1/user/AuthTestSupport.kt
+++ b/app-main/src/test/kotlin/test/endpoint/v1/user/AuthTestSupport.kt
@@ -16,6 +16,11 @@ fun getAuthorizedTokenFrom(
     response: UserLoginResponse
 ): String = response.authorizedToken
 
+fun getSubjectFrom(token: String, publicKey: PublicKey): String = getClaimsFrom(
+    issuedToken = token,
+    publicKey = publicKey
+).body.subject
+
 fun getClaimsFrom(
     issuedToken: String,
     publicKey: Key,

--- a/app-main/src/test/kotlin/test/endpoint/v1/user/AuthTestSupport.kt
+++ b/app-main/src/test/kotlin/test/endpoint/v1/user/AuthTestSupport.kt
@@ -19,7 +19,7 @@ fun getAuthorizedTokenFrom(
 fun getClaimsFrom(
     issuedToken: String,
     publicKey: Key,
-): Jws<Claims>? {
+): Jws<Claims> {
     return Jwts.parserBuilder()
         .setSigningKey(publicKey)
         .build()

--- a/app-main/src/test/kotlin/test/endpoint/v1/user/UserApiTestSupport.kt
+++ b/app-main/src/test/kotlin/test/endpoint/v1/user/UserApiTestSupport.kt
@@ -4,18 +4,14 @@
  */
 package test.endpoint.v1.user
 
-import com.flab.hsw.endpoint.ApiPaths
-import com.flab.hsw.endpoint.common.response.SimpleResponse
 import com.flab.hsw.endpoint.v1.ApiPathsV1
 import com.flab.hsw.endpoint.v1.user.common.UserResponse
 import com.flab.hsw.endpoint.v1.user.create.CreateUserRequest
 import com.flab.hsw.endpoint.v1.user.edit.EditUserRequest
 import com.flab.hsw.endpoint.v1.user.login.UserLoginRequest
-import io.restassured.RestAssured.request
 import io.restassured.response.Response
 import org.springframework.restdocs.payload.FieldDescriptor
 import test.endpoint.v1.usersId
-import testcase.large.RestAssuredLargeTestBase
 import testcase.large.endpoint.EndpointLargeTestBase
 import java.net.URI
 import java.util.*
@@ -96,5 +92,3 @@ fun EndpointLargeTestBase.createRandomUser(
 ): UserResponse {
     return createUserApi(request).expect2xx(UserResponse::class)
 }
-
-fun EndpointLargeTestBase.getPublicKeyApi(): String = request().get(ApiPaths.PUBLIC_KEY).path("body.result")

--- a/app-main/src/test/kotlin/testcase/large/endpoint/v1/user/LoginUserApiSpec.kt
+++ b/app-main/src/test/kotlin/testcase/large/endpoint/v1/user/LoginUserApiSpec.kt
@@ -1,12 +1,15 @@
 package testcase.large.endpoint.v1.user
 
 import com.flab.hsw.core.domain.user.User
+import com.flab.hsw.endpoint.ApiPaths
 import com.flab.hsw.endpoint.v1.user.common.UserResponse
 import com.flab.hsw.endpoint.v1.user.create.CreateUserRequest
 import com.flab.hsw.endpoint.v1.user.login.UserLoginRequest
 import com.flab.hsw.endpoint.v1.user.login.UserLoginResponse
+import com.flab.hsw.util.JwtTokenManager
 import com.github.javafaker.service.FakeValuesService
 import com.github.javafaker.service.RandomService
+import io.restassured.http.Header
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.DisplayName
@@ -15,8 +18,6 @@ import org.junit.jupiter.api.assertAll
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import test.endpoint.v1.user.*
-import test.endpoint.v1.user.getAuthorizedTokenFrom
-import test.endpoint.v1.user.getClaimsFrom
 import testcase.large.endpoint.EndpointLargeTestBase
 import java.security.KeyFactory
 import java.security.spec.X509EncodedKeySpec
@@ -93,13 +94,15 @@ class LoginUserApiSpec : EndpointLargeTestBase() {
         ).expect4xx(HttpStatus.UNAUTHORIZED)
     }
 
-    @DisplayName("사용자가 로그인에 성공한 경우, 정상적으로 'lastActiveAt' 프로퍼티가 업데이트되며, 인증 토큰이 발행됩니다.")
+    @DisplayName("사용자가 로그인에 성공한 경우, 정상적으로 'lastActiveAt' 프로퍼티가 업데이트되며, 인증 토큰(Access, Refresh)이 발행됩니다.")
     @Test
     fun lastActiveAtPropertyIsUpdatedWhenNormalCase() {
         // given:
         val preparedPassword = FakeValuesService(Locale.ENGLISH, RandomService()).regexify(User.PASSWORD_REGEX)
         val preparedUser = createRandomUser(CreateUserRequest.random(password = preparedPassword))
         val preparedLastActiveTime = preparedUser.lastActiveAt
+        val publicKey = KeyFactory.getInstance("RSA")
+            .generatePublic(X509EncodedKeySpec(Base64.getDecoder().decode(publicKey)))
 
         // when:
         val response = loginUserApi(
@@ -107,21 +110,22 @@ class LoginUserApiSpec : EndpointLargeTestBase() {
                 loginId = preparedUser.loginId,
                 password = preparedPassword
             )
-        ).expect2xx(UserLoginResponse::class)
+        )
 
         // and:
-        val issuedToken = getAuthorizedTokenFrom(response)
         val loginSuccessUser = getUserApi(preparedUser.id).expect2xx(UserResponse::class)
-        val loginIdFromIssuedToken = getClaimsFrom(
-            issuedToken = issuedToken,
-            publicKey = KeyFactory.getInstance("RSA")
-                .generatePublic(X509EncodedKeySpec(Base64.getDecoder().decode(publicKey)))
-        )?.body?.subject
+
+        val issuedAccessToken = getAuthorizedTokenFrom(response.expect2xx(UserLoginResponse::class))
+        val loginIdFromAccessToken = getSubjectFrom(issuedAccessToken, publicKey)
+
+        val issuedRefreshToken = response.getCookie(JwtTokenManager.REFRESH_TOKEN_COOKIE_KEY)
+        val loginIdFromRefreshToken = getSubjectFrom(issuedRefreshToken, publicKey)
 
         // then:
         assertAll(
             { assertThat(loginSuccessUser.lastActiveAt > preparedLastActiveTime, `is`(true)) },
-            { assertThat(loginIdFromIssuedToken, `is`(preparedUser.loginId)) }
+            { assertThat(loginIdFromAccessToken, `is`(preparedUser.loginId)) },
+            { assertThat(loginIdFromRefreshToken, `is`(preparedUser.loginId)) },
         )
     }
 }

--- a/app-main/src/test/kotlin/testcase/small/util/JwtTokenManagerSpec.kt
+++ b/app-main/src/test/kotlin/testcase/small/util/JwtTokenManagerSpec.kt
@@ -33,7 +33,7 @@ class JwtTokenManagerSpec {
         val randomUser = randomUser()
 
         // when:
-        val returnClaimsBody = sut.validAndReturnClaims(sut.createBy(randomUser))?.body
+        val returnClaimsBody = sut.validAndReturnClaims(sut.createAccessTokenBy(randomUser.loginId)).body
 
         // then:
        assertThat(returnClaimsBody?.subject, `is`(randomUser.loginId))

--- a/app-main/src/test/kotlin/testcase/small/util/JwtTokenManagerSpec.kt
+++ b/app-main/src/test/kotlin/testcase/small/util/JwtTokenManagerSpec.kt
@@ -18,7 +18,12 @@ class JwtTokenManagerSpec {
     @BeforeEach
     fun setup() {
         val keyPair = returnKeySet()
-        sut = JwtTokenManager(publicKey = keyPair.first, privateKey = keyPair.second, expirePeriod = 7200L)
+        sut = JwtTokenManager(
+            publicKey = keyPair.first,
+            privateKey = keyPair.second,
+            accessTokenExpirePeriod = 7200L,
+            refreshTokenExpirePeriod = 1209600L
+        )
     }
 
     @DisplayName("정상적으로 토큰이 생성된 경우, 회원의 loginId가 subject에 주입됩니다.")

--- a/app-main/src/test/resources/application.yml
+++ b/app-main/src/test/resources/application.yml
@@ -42,4 +42,5 @@ auth:
 
 jwt:
   token:
-    expiredPeriod: 7200
+    expiredPeriod:
+      access: 7200

--- a/app-main/src/test/resources/application.yml
+++ b/app-main/src/test/resources/application.yml
@@ -44,3 +44,4 @@ jwt:
   token:
     expiredPeriod:
       access: 7200
+      refresh: 1209600


### PR DESCRIPTION
### Context and motivation

- #40 기능 구현입니다.
- #30 내 언급된 `Refresh Token` 구현입니다.
 
---

### Key implements

- 기존 피드백 사항처럼 `토큰 만료시간`을 외부 주입 형태로 구현했습니다.
- Refresh Token 발행 시 브라우저 단에서 탈취 가능성을 낮추고자 **Http-Only 쿠키**에 담아 반환합니다.
- Refresh Token 발행 시 별도로 서버에 저장하지 않습니다. 
    - 클라이언트는 로컬에 Refresh Token을 보관하다 Access Token이 만료된 경우에 Access Token을 재발행합니다.

---

### Notes

- Refresh Token(이하 RT)은 오직 로그인 프로세스를 통해서만 발급됩니다.
    - Access Token(이하 AT) 검증에 성공한 경우 RT을 재발급하는 경우, 영원히 보안이 파괴될 우려가 있습니다.
    - 만약 공격자가 RT을 탈취하더라도 (`Claim`내에 저장된 ID를 변경하는 경우 서명이 달라지기에) 최초 발급받은 ID에 대한 AT 재발행만 가능합니다.